### PR TITLE
refactor: strictモードを有効にする #18

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 $finder = PhpCsFixer\Finder::create()
     ->in([
         __DIR__ . '/src',
@@ -36,6 +38,8 @@ return (new PhpCsFixer\Config())
         'compact_nullable_typehint' => true,
         'concat_space' => ['spacing' => 'one'],
         'constant_case' => ['case' => 'lower'],
+
+        'declare_strict_types' => true,
 
         'explicit_string_variable' => true,
 

--- a/src/Rules/ArrayRule.php
+++ b/src/Rules/ArrayRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation\Rules;
 
 class ArrayRule implements RuleInterface

--- a/src/Rules/MaxLengthRule.php
+++ b/src/Rules/MaxLengthRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation\Rules;
 
 class MaxLengthRule implements RuleInterface

--- a/src/Rules/MaxRule.php
+++ b/src/Rules/MaxRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation\Rules;
 
 class MaxRule implements RuleInterface

--- a/src/Rules/MinLengthRule.php
+++ b/src/Rules/MinLengthRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation\Rules;
 
 class MinLengthRule implements RuleInterface

--- a/src/Rules/MinRule.php
+++ b/src/Rules/MinRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation\Rules;
 
 class MinRule implements RuleInterface

--- a/src/Rules/NotExistsRuleException.php
+++ b/src/Rules/NotExistsRuleException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation\Rules;
 
 use Exception;

--- a/src/Rules/NotRegexRule.php
+++ b/src/Rules/NotRegexRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation\Rules;
 
 class NotRegexRule implements RuleInterface
@@ -14,6 +16,6 @@ class NotRegexRule implements RuleInterface
      */
     public function validate(mixed $value, mixed $parameters): bool
     {
-        return ! preg_match($parameters, $value);
+        return ! (preg_match($parameters, $value) === 1 ? true : false);
     }
 }

--- a/src/Rules/NullableRule.php
+++ b/src/Rules/NullableRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation\Rules;
 
 class NullableRule implements RuleInterface

--- a/src/Rules/NumericRule.php
+++ b/src/Rules/NumericRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation\Rules;
 
 class NumericRule implements RuleInterface

--- a/src/Rules/RegexRule.php
+++ b/src/Rules/RegexRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation\Rules;
 
 class RegexRule implements RuleInterface
@@ -14,6 +16,6 @@ class RegexRule implements RuleInterface
      */
     public function validate(mixed $value, mixed $parameters): bool
     {
-        return preg_match($parameters, $value);
+        return preg_match($parameters, $value) === 1 ? true : false;
     }
 }

--- a/src/Rules/RequiredRule.php
+++ b/src/Rules/RequiredRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation\Rules;
 
 class RequiredRule implements RuleInterface

--- a/src/Rules/RequiredWithAllRule.php
+++ b/src/Rules/RequiredWithAllRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation\Rules;
 
 use Validation\ValidateData;

--- a/src/Rules/RequiredWithRule.php
+++ b/src/Rules/RequiredWithRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation\Rules;
 
 use Validation\ValidateData;

--- a/src/Rules/RequiredWithoutAllRule.php
+++ b/src/Rules/RequiredWithoutAllRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation\Rules;
 
 use Validation\ValidateData;

--- a/src/Rules/RequiredWithoutRule.php
+++ b/src/Rules/RequiredWithoutRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation\Rules;
 
 use Validation\ValidateData;

--- a/src/Rules/RuleInterface.php
+++ b/src/Rules/RuleInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation\Rules;
 
 interface RuleInterface

--- a/src/Rules/SameLengthRule.php
+++ b/src/Rules/SameLengthRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation\Rules;
 
 class SameLengthRule implements RuleInterface

--- a/src/Rules/SameSizeRule.php
+++ b/src/Rules/SameSizeRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation\Rules;
 
 class SameSizeRule implements RuleInterface

--- a/src/Rules/StringRule.php
+++ b/src/Rules/StringRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation\Rules;
 
 class StringRule implements RuleInterface

--- a/src/ValidateData.php
+++ b/src/ValidateData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation;
 
 class ValidateData

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Validation;
 
 use Validation\Rules\NotExistsRuleException;

--- a/tests/Rules/ArrayRuleTest.php
+++ b/tests/Rules/ArrayRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Rules;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/MaxLengthRuleTest.php
+++ b/tests/Rules/MaxLengthRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Rules;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/MaxRuleTest.php
+++ b/tests/Rules/MaxRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Rules;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/MinLengthRuleTest.php
+++ b/tests/Rules/MinLengthRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Rules;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/MinRuleTest.php
+++ b/tests/Rules/MinRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Rules;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/NotRegexRuleTest.php
+++ b/tests/Rules/NotRegexRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Rules;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/NullableRuleTest.php
+++ b/tests/Rules/NullableRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Rules;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/NumericRuleTest.php
+++ b/tests/Rules/NumericRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Rules;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/RegexRuleTest.php
+++ b/tests/Rules/RegexRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Rules;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/RequiredRuleTest.php
+++ b/tests/Rules/RequiredRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Rules;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/RequiredWithAllRuleTest.php
+++ b/tests/Rules/RequiredWithAllRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Rules;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/RequiredWithRuleTest.php
+++ b/tests/Rules/RequiredWithRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Rules;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/RequiredWithoutAllRuleTest.php
+++ b/tests/Rules/RequiredWithoutAllRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Rules;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/RequiredWithoutRuleTest.php
+++ b/tests/Rules/RequiredWithoutRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Rules;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/SameLengthRuleTest.php
+++ b/tests/Rules/SameLengthRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Rules;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/SameSizeRuleTest.php
+++ b/tests/Rules/SameSizeRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Rules;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Rules/StringRuleTest.php
+++ b/tests/Rules/StringRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Rules;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/ValidateDataTest.php
+++ b/tests/ValidateDataTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests;
 
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
php-cs-fixerにて、自動的にstrictモードを有効にするように修正。
上記設定適応後、テストで失敗した箇所があるので、併せて修正。